### PR TITLE
Remove bug: 'dpdSocket' must return a value from $get factory method.

### DIFF
--- a/angular-dpd.js
+++ b/angular-dpd.js
@@ -5,7 +5,7 @@ var angularDpdSockets = [];
 angular.module('dpd', []).value('dpdConfig', [])
     .factory('dpdSocket', function($rootScope, dpdConfig) {
         if (!dpdConfig.useSocketIo) {
-            return undefined;
+            return false;
         }
         if (!io.connect) {
             throw ('angular-dpd: socket.io library not available, includ the client library or set dpdConfig.useSocketIo = false');


### PR DESCRIPTION
Dont know if this works when sockets are on, but it solved my bug with sockets disabled

Error: [$injector:undef] Provider 'dpdSocket' must return a value from $get factory method.
